### PR TITLE
Add the tab name to the Worksheet class

### DIFF
--- a/pyxlsb/workbook.py
+++ b/pyxlsb/workbook.py
@@ -64,6 +64,7 @@ class Workbook(object):
     if idx < 1 or idx > len(self._sheets):
       raise IndexError('sheet index out of range')
 
+    name = self._sheets[idx - 1][0]
     target = self._sheets[idx - 1][1].split('/')
 
     temp = TemporaryFile()
@@ -79,7 +80,7 @@ class Workbook(object):
     else:
       rels_temp = None
 
-    return Worksheet(fp=temp, rels_fp=rels_temp, stringtable=self.stringtable, debug=self._debug)
+    return Worksheet(name=name, fp=temp, rels_fp=rels_temp, stringtable=self.stringtable, debug=self._debug)
 
   def close(self):
     self._zf.close()

--- a/pyxlsb/worksheet.py
+++ b/pyxlsb/worksheet.py
@@ -11,8 +11,9 @@ if sys.version_info > (3,):
 Cell = namedtuple('Cell', ['r', 'c', 'v'])
 
 class Worksheet(object):
-  def __init__(self, fp, rels_fp=None, stringtable=None, debug=False):
+  def __init__(self, name, fp, rels_fp=None, stringtable=None, debug=False):
     super(Worksheet, self).__init__()
+    self.name = name
     self._reader = BIFF12Reader(fp=fp, debug=debug)
     self._rels_fp = rels_fp
     if rels_fp is not None:


### PR DESCRIPTION
Hi @willtrnr , are you open to the idea of adding the name on the worksheet tab to the Worksheet class?  That is, including "Sheet 1", "Sheet 2", etc. in Worksheet objects.  It's useful to have the name of the tab on the worksheet objects directly so that they can be referenced in any logging or error messages.  Right now, the worksheet names are stored only in the Workbook, and when a Worksheet object is instantiated from the Workbook class, the worksheet object is handed to the client without the name of the worksheet included.  Hence, unless I'm missing something, it's difficult to refer to the worksheet in any unique and meaningful way.

`openpyxl` has a worksheet property of "title".  `xlrd` has a worksheet property of "name".  Hence, I thought an attribute of "name" could be added to the `pyxlsb` Worksheet class to store the tab name.  It's a small change to the Worksheet class (which has been tested), as shown in this PR.

If you would like README.rst updated with this new attribute, I'm happy to do so.