### PR TITLE
fix lines resulting in string-bytes comparison error

### DIFF
--- a/pyxlsb/reader.py
+++ b/pyxlsb/reader.py
@@ -144,7 +144,7 @@ class BIFF12Reader(object):
     v = 0
     for i in range(4):
       byte = self._fp.read(1)
-      if byte == b'':
+      if not byte:
         return None
       byte = uint8_t.unpack(byte)[0]
       v += byte << 8 * i

--- a/pyxlsb/reader.py
+++ b/pyxlsb/reader.py
@@ -47,7 +47,7 @@ class RecordReader(object):
 
   def read_byte(self):
     byte = self._fp.read(1)
-    if byte == b'':
+    if not byte:
       return None
     return uint8_t.unpack(byte)[0]
 
@@ -156,7 +156,7 @@ class BIFF12Reader(object):
     v = 0
     for i in range(4):
       byte = self._fp.read(1)
-      if byte == b'':
+      if not byte:
         return None
       byte = uint8_t.unpack(byte)[0]
       v += (byte & 0x7F) << (7 * i)

--- a/pyxlsb/reader.py
+++ b/pyxlsb/reader.py
@@ -144,7 +144,7 @@ class BIFF12Reader(object):
     v = 0
     for i in range(4):
       byte = self._fp.read(1)
-      if byte == '':
+      if byte == b'':
         return None
       byte = uint8_t.unpack(byte)[0]
       v += byte << 8 * i
@@ -156,7 +156,7 @@ class BIFF12Reader(object):
     v = 0
     for i in range(4):
       byte = self._fp.read(1)
-      if byte == '':
+      if byte == b'':
         return None
       byte = uint8_t.unpack(byte)[0]
       v += (byte & 0x7F) << (7 * i)


### PR DESCRIPTION
Using python 3.8.3 I got an exception: "BytesWarning: Comparison between bytes and string", which is fixed by comparing with an empty bytestring instead of a normal empty string.